### PR TITLE
Documentation - Ensure that the existing kube-state-metrics exports the labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Example:
             --namespace doit-eks-metrics \
             --create-namespace
 
+> Make sure you've added these [arguments](https://github.com/doitintl/doit-eks-lens-helm-chart/blob/main/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml#L180) to your existing `kube-state-metrics` installation.
+
+
 To install the doit-eks-lens chart in a self-managed EC2 based kubernetes cluster:
 Ensure the required kubernetes secrets (aws-access-key-id,aws-secret-access-key) are created before installing the helm chart.
 


### PR DESCRIPTION
Hello,

I've added a line to the documentation to ensure that users have exported the labels in the existing `kube-state-metrics`.

Please let me know if you need any other details.

Sincerely

