### PR TITLE
Change .Values.*.image from map to string

### DIFF
--- a/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
+++ b/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
@@ -236,3 +236,4 @@ spec:
   - name: http-metrics
     port: 8080
 {{ end }}
+

--- a/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
+++ b/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
@@ -187,7 +187,11 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: "cluster.local"
+        {{- if kindIs "string" .Values.kubeStateMetrics.image }}
         image: {{ .Values.kubeStateMetrics.image }}
+        {{- else if kindIs "map" .Values.kubeStateMetrics.image }}
+        image: {{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}
+        {{- end }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
+++ b/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
@@ -187,7 +187,12 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: "cluster.local"
-        image: {{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}
+        image: |
+          {{- if kindIs "string" .Values.kubeStateMetrics.image }}
+          {{ .Values.kubeStateMetrics.image }}
+          {{- else if kindIs "map" .Values.kubeStateMetrics.image }}
+          {{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}
+          {{- end }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
+++ b/charts/doit-eks-lens/templates/doit-kube-state-metrics.yaml
@@ -187,12 +187,7 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: "cluster.local"
-        image: |
-          {{- if kindIs "string" .Values.kubeStateMetrics.image }}
-          {{ .Values.kubeStateMetrics.image }}
-          {{- else if kindIs "map" .Values.kubeStateMetrics.image }}
-          {{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}
-          {{- end }}
+        image: {{ .Values.kubeStateMetrics.image }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/templates/doit-otelcol.yaml
+++ b/charts/doit-eks-lens/templates/doit-otelcol.yaml
@@ -398,7 +398,11 @@ spec:
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }} 
+        {{- if kindIs "string" .Values.collector.otelcol.image }}
         image: {{ .Values.collector.otelcol.image }}
+        {{- else if kindIs "map" .Values.collector.otelcol.image }}
+        image: {{ .Values.collector.otelcol.image.repository }}:{{ .Values.collector.otelcol.image.tag }}
+        {{- end }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/templates/doit-otelcol.yaml
+++ b/charts/doit-eks-lens/templates/doit-otelcol.yaml
@@ -436,3 +436,4 @@ spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       {{- end }}
+

--- a/charts/doit-eks-lens/templates/doit-otelcol.yaml
+++ b/charts/doit-eks-lens/templates/doit-otelcol.yaml
@@ -149,10 +149,10 @@ data:
     receivers:
       prometheus_simple:
           collection_interval: 60s
-          {{- if .Values.kubeStateMetrics.install }}
+          {{- if .Values.collector.otelcol.install }}
           endpoint: 'kube-state-metrics:8080'
           {{ else }}
-          endpoint: {{ squote .Values.collector.otelcol.kubeStateMetrics.endpoint }}
+          endpoint: {{ squote .Values.collector.otelcol.collector.otelcol.endpoint }}
           {{- end }}
           metrics_path: '/metrics'
           tls:
@@ -398,7 +398,12 @@ spec:
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }} 
-        image: {{ .Values.collector.otelcol.image.repository }}:{{ .Values.collector.otelcol.image.tag }}
+        image: |
+          {{- if kindIs "string" .Values.collector.otelcol.image }}
+          {{ .Values.collector.otelcol.image }}
+          {{- else if kindIs "map" .Values.collector.otelcol.image }}
+          {{ .Values.collector.otelcol.image.repository }}:{{ .Values.collector.otelcol.image.tag }}
+          {{- end }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/templates/doit-otelcol.yaml
+++ b/charts/doit-eks-lens/templates/doit-otelcol.yaml
@@ -149,10 +149,10 @@ data:
     receivers:
       prometheus_simple:
           collection_interval: 60s
-          {{- if .Values.collector.otelcol.install }}
+          {{- if .Values.kubeStateMetrics.install }}
           endpoint: 'kube-state-metrics:8080'
           {{ else }}
-          endpoint: {{ squote .Values.collector.otelcol.collector.otelcol.endpoint }}
+          endpoint: {{ squote .Values.collector.otelcol.kubeStateMetrics.endpoint }}
           {{- end }}
           metrics_path: '/metrics'
           tls:
@@ -398,12 +398,7 @@ spec:
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }} 
-        image: |
-          {{- if kindIs "string" .Values.collector.otelcol.image }}
-          {{ .Values.collector.otelcol.image }}
-          {{- else if kindIs "map" .Values.collector.otelcol.image }}
-          {{ .Values.collector.otelcol.image.repository }}:{{ .Values.collector.otelcol.image.tag }}
-          {{- end }}
+        image: {{ .Values.collector.otelcol.image }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/doit-eks-lens/values.yaml
+++ b/charts/doit-eks-lens/values.yaml
@@ -3,7 +3,7 @@ k8s_platform: eks
 kubeStateMetrics:
   install: true
   replicas: 1
-  image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2"
+  image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
   nodeSelector: {}
@@ -11,7 +11,7 @@ kubeStateMetrics:
 collector:
   otelcol:
     replicas: 1
-    image: "otel/opentelemetry-collector-contrib:0.83.0"
+    image: otel/opentelemetry-collector-contrib:0.83.0
     kubeStateMetrics:
       endpoint: "kube-state-metrics:8080"
     ## Ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md

--- a/charts/doit-eks-lens/values.yaml
+++ b/charts/doit-eks-lens/values.yaml
@@ -3,9 +3,7 @@ k8s_platform: eks
 kubeStateMetrics:
   install: true
   replicas: 1
-  image:
-    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-    tag: v2.9.2
+  image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2"
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
   nodeSelector: {}
@@ -13,9 +11,7 @@ kubeStateMetrics:
 collector:
   otelcol:
     replicas: 1
-    image:
-      repository: otel/opentelemetry-collector-contrib
-      tag: 0.83.0
+    image: "otel/opentelemetry-collector-contrib:0.83.0"
     kubeStateMetrics:
       endpoint: "kube-state-metrics:8080"
     ## Ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md


### PR DESCRIPTION
In the Deployment template the image string is concatenated from two separate values that don't really need to be separate. If we expect a user to provide the entire string in the [doitintl/terraform-eks-lens](https://github.com/doitintl/terraform-eks-lens/blob/main/cluster/README.md#terraform-eks-lens-cluster) repo it shouldn't be a big ask to do so here.

The impetus for this seemingly arbitrary change is to make it easier to support another PR I am working on that will allow  installation of this helm chart using the  [doitintl/terraform-eks-lens](https://github.com/doitintl/terraform-eks-lens) module.